### PR TITLE
Allow modifying xmllint args and validate file names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.0.0
 
-Officially supported Node.js version is raised from 12 to 14, which is a **breaking change**.
+Officially supported Node.js version is raised from 12 to 16, which is a **breaking change**.
 
 Optimizes the XML file input reading, by switching from Emscripten `FS.createDataFile` to
 `FS.writeFile`.  
@@ -20,7 +20,22 @@ that occurred on very large outputs.
 In some cases, the old output handling resulted in output not having a last line break at the end of
 output. In the new output, the last line break is always included. This could **break** some tests 
 where you expect some exact output that didn't previously have said line break in the end.  
-Otherwise, there shouldn't be any breaking changes to the output format.
+
+We now validate that XML and Schema file names do not start with a dash (`-`), or contain 
+a space and a dash (` -`), which would cause xmllint to interpret the file name
+as a command line option. File names could be user-inputted, so this change is to
+prevent end users from accidentally or maliciously changing the expected behaviour of
+the validation. It is recommended, though, to also do stricter validation of file names
+if you accept them from user input. 
+This is a **breaking change** if you previously passed in file names that started with a dash.  
+There is a new option `disableFileNameValidation` to disable this validation if you want
+to keep the old behaviour and accept any kind of file name.
+
+Adds new optional option `modifyArguments`, which allows you to arbitrarily add
+or modify the command line arguments that are passed to the xmllint command. The
+option is a function that receives the current arguments as an array, and should
+return a new array of string arguments.  
+Closes [#22](https://github.com/noppa/xmllint-wasm/issues/22).
 
 ## 4.0.2
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -24,6 +24,14 @@ interface XMLLintOptionsBase {
    * Note that xmllint only supports UTF-8 encoded files.
   */
   readonly xml: XMLInput | ReadonlyArray<XMLInput>;
+	/**
+	 * By default, we do some sanity checks on the file names
+	 * to make sure they won't be intepreted by xmllint as command line arguments.
+	 * This is new in version 5 of the library. If you want to keep the old behavior
+	 * and allow filenames starting with dashes, you can set this to true.
+	 * Default: false.
+	 */
+	readonly disableFileNameValidation?: boolean;
   /**
    * Other files that should be added to Emscripten's in-memory
    * file system so that xmllint can access them.
@@ -50,6 +58,13 @@ interface XMLLintOptionsBase {
 	* The following example would set the max memory to 2GiB.
 	*/
   readonly maxMemoryPages?: number;
+
+	/**
+	 * Allows arbitrary modifications to the arguments passed to xmllint.
+	 * Useful for adding custom options that are not supported first-class by
+	 * this library.
+	 */
+	readonly modifyArguments?: (args: string[]) => string[];
 }
 
 export type XMLLintOptions = XMLLintOptionsBase & (Schema | Normalization | (Schema & Normalization));

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -15,6 +15,14 @@ type BaseXMLLintOptions = {|
    * Note that xmllint only supports UTF-8 encoded files.
   */
   +xml: XMLInput | $ReadOnlyArray<XMLInput>;
+	/**
+	 * By default, we do some sanity checks on the file names
+	 * to make sure they won't be intepreted by xmllint as command line arguments.
+	 * This is new in version 5 of the library. If you want to keep the old behavior
+	 * and allow filenames starting with dashes, you can set this to true.
+	 * Default: false.
+	 */
+	+disableFileNameValidation?: ?boolean;
   /**
    * Other files that should be added to Emscripten's in-memory
    * file system so that xmllint can access them.
@@ -41,6 +49,13 @@ type BaseXMLLintOptions = {|
 	* The following example would set the max memory to 2GiB.
 	*/
   +maxMemoryPages?: number;
+
+	/**
+	 * Allows arbitrary modifications to the arguments passed to xmllint.
+	 * Useful for adding custom options that are not supported first-class by
+	 * this library.
+	 */
+	+modifyArguments?: (args: string[]) => string[];
 |};
 
 export type XMLLintOptionsForValidation = {| 

--- a/test/test.js
+++ b/test/test.js
@@ -86,6 +86,43 @@ async function testWithInvalidFile() {
 	assert.deepEqual(result, expectedErrorResult);
 }
 
+async function testWithInvalidFileName() {
+	let error1;
+	try {
+		await xmllint.validateXML({
+			xml: {fileName: '--foo', contents: xmlValid},
+			...schemaOptions,
+		});
+	} catch (err) {
+		error1 = err;
+	}
+	assert.match(String(error1), /Invalid file name "--foo"/);
+
+	let error2;
+	try {
+		await xmllint.validateXML({
+			xml: {fileName: 'foo -bar', contents: xmlValid},
+			...schemaOptions,
+		});
+	} catch (err) {
+		error2 = err;
+	}
+	assert.match(String(error2), /Invalid file name "foo -bar"/);
+}
+
+async function testWithCustomOptions() {
+	const {rawOutput} = await xmllint.validateXML({
+		xml: [],
+		modifyArguments(args) {
+			assert(Array.isArray(args));
+			assert(args.every(arg => typeof arg === 'string'));
+
+			return ['--version'];
+		}
+	});
+	assert.match(rawOutput, /using libxml version/);
+}
+
 async function testWithTwoFiles() {
 	const input = [
 		{
@@ -200,6 +237,8 @@ runTests(
 	testWithValidFileForFormatWithoutSchema,
 	testWithValidFileForC14n,
 	testWithInvalidFile,
+	testWithInvalidFileName,
+	testWithCustomOptions,
 	testWithTwoFiles,
 	testWithLargeFile,
 );

--- a/typings-test/flowtype.test-output.txt
+++ b/typings-test/flowtype.test-output.txt
@@ -14,14 +14,14 @@ Cannot call `xmllint.validateXML` with object literal bound to `options` because
        ^ [1]
 
 References:
-   ../index-node.js.flow:68:5
-   68|   | XMLLintOptionsForValidation
+   ../index-node.js.flow:83:5
+   83|   | XMLLintOptionsForValidation
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   ../index-node.js.flow:69:5
-   69|   | XMLLintOptionsForNormalization
+   ../index-node.js.flow:84:5
+   84|   | XMLLintOptionsForNormalization
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   ../index-node.js.flow:70:5
-   70|   | XMLLintOptionsForValidationAndNormalization; 
+   ../index-node.js.flow:85:5
+   85|   | XMLLintOptionsForValidationAndNormalization; 
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 


### PR DESCRIPTION
Adds new optional option `modifyArguments`, which allows you to arbitrarily add or modify the command line arguments that are passed to the xmllint command. The option is a function that receives the current arguments as an array, and should return a new array of string arguments.
Closes [#22](https://github.com/noppa/xmllint-wasm/issues/22).

Also adds validation that XML and Schema file names do not start with a dash (`-`), or contain a space and a dash (` -`), which would cause xmllint to interpret the file name as a command line option. File names could be user-inputted, so this change is to prevent end users from accidentally or maliciously changing the expected behaviour of the validation. It is recommended, though, to also do stricter validation of file names if you accept them from user input. This is a **breaking change** if you previously passed in file names that started with a dash. There is a new option `disableFileNameValidation` to disable this validation if you want to keep the old behaviour and accept any kind of file name.