### PR TITLE
Add streaming support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 5.1.0
+
+Add support for xmllint's `--stream` option, which is useful when  
+validating large XML files. 
+Supporting this feature required compiling libxml2 with `reader` support, which
+adds about 30K, or 4%, increase to the wasm binary size.
+
+Closes [#27](https://github.com/noppa/xmllint-wasm/issues/27).
+
 ## 5.0.0
 
 Officially supported Node.js version is raised from 12 to 16, which is a **breaking change**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "xmllint-wasm",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "xmllint-wasm",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.19.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,10 +17,10 @@
         "typescript": "5.4.5"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16"
       },
       "peerDependencies": {
-        "@types/node": ">=14"
+        "@types/node": ">=16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xmllint-wasm",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Fork of https://www.npmjs.com/package/xmllint with some updates",
   "main": "index-node.js",
   "browser": "index-browser.mjs",

--- a/script/libxml2
+++ b/script/libxml2
@@ -9,6 +9,7 @@ emconfigure ../libxml2/configure --disable-shared \
   --with-minimum --with-http=no --with-ftp=no \
   --with-python=no --with-threads=no \
   --with-output --with-c14n \
-  --with-schemas --with-schematron
+  --with-schemas --with-schematron \
+  --with-reader
 emmake make
 cd ..

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -60,6 +60,14 @@ interface XMLLintOptionsBase {
   readonly maxMemoryPages?: number;
 
 	/**
+	 * Use xmllint's streaming API.
+	 * Useful when used in combination with --relaxng or --valid options for validation of
+	 * files that are too large to be held in memory.
+	 * Default: false.
+	 */
+	readonly stream?: boolean;
+
+	/**
 	 * Allows arbitrary modifications to the arguments passed to xmllint.
 	 * Useful for adding custom options that are not supported first-class by
 	 * this library.

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,10 @@ function preprocessOptions(options) {
 		args.push('--noout');
 	}
 
+	if (options.stream) {
+		args.push('--stream');
+	}
+
 	xmls.forEach(function(xml) {
 		args.push(xml['fileName']);
 	});

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -50,6 +50,14 @@ type BaseXMLLintOptions = {|
 	*/
   +maxMemoryPages?: number;
 
+  /**
+   * Use xmllint's streaming API.
+   * Useful when used in combination with --relaxng or --valid options for validation of
+   * files that are too large to be held in memory.
+   * Default: false.
+   */
+  +stream?: boolean;
+
 	/**
 	 * Allows arbitrary modifications to the arguments passed to xmllint.
 	 * Useful for adding custom options that are not supported first-class by

--- a/typings-test/flowtype.test-output.txt
+++ b/typings-test/flowtype.test-output.txt
@@ -14,14 +14,14 @@ Cannot call `xmllint.validateXML` with object literal bound to `options` because
        ^ [1]
 
 References:
-   ../index-node.js.flow:83:5
-   83|   | XMLLintOptionsForValidation
+   ../index-node.js.flow:91:5
+   91|   | XMLLintOptionsForValidation
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^ [2]
-   ../index-node.js.flow:84:5
-   84|   | XMLLintOptionsForNormalization
+   ../index-node.js.flow:92:5
+   92|   | XMLLintOptionsForNormalization
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [3]
-   ../index-node.js.flow:85:5
-   85|   | XMLLintOptionsForValidationAndNormalization; 
+   ../index-node.js.flow:93:5
+   93|   | XMLLintOptionsForValidationAndNormalization; 
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ [4]
 
 


### PR DESCRIPTION
Add support for xmllint streaming option

Make validation of large XML files easier on the memory use by
instructing xmllint to stream through it instead of reading the whole
thing into memory at once.

This feature requires compiling with "reader" support.

This adds about 30K to the size of the wasm binary (732K vs 761K), which
seems reasonable to me for the added possibilities / performance gains
with large files.

Closes [#27](https://github.com/noppa/xmllint-wasm/issues/27).