### PR TITLE
Reject promise when WASM file fails to load

### DIFF
--- a/src/worker-post.js
+++ b/src/worker-post.js
@@ -45,6 +45,18 @@
 				stderr += text + '\n';
 			},
 			onExit,
+			onAbort(reason) {
+				const message = {
+					exitCode: -1,
+					stdout: '',
+					stderr: 'WASM Abort: ' + reason,
+				};
+				// #ifdef node
+				parentPort.postMessage(message);
+				// #ifdef browser
+				postMessage(message);
+				// #endif
+			},
 			wasmMemory,
 			// #ifdef browser
 			locateFile(path) {

--- a/test/test.js
+++ b/test/test.js
@@ -240,6 +240,24 @@ async function runTests(...tests) {
 	console.log('All tests passed.');
 }
 
+async function testWithMissingWasmFile() {
+	const wasmPath = require('path').resolve(__dirname, '../xmllint.wasm');
+	const tmpPath = wasmPath + '.bak';
+	fs.renameSync(wasmPath, tmpPath);
+	try {
+		let error;
+		try {
+			await xmllint.validateXML({xml: '<foo/>'});
+		} catch (err) {
+			error = err;
+		}
+		assert(error, 'Expected promise to reject when WASM file is missing');
+		assert.match(String(error.message), /WASM Abort/);
+	} finally {
+		fs.renameSync(tmpPath, wasmPath);
+	}
+}
+
 runTests(
 	testWithValidFile,
 	testWithValidFileForFormat,
@@ -250,4 +268,5 @@ runTests(
 	testWithCustomOptions,
 	testWithTwoFiles,
 	testWithLargeFile,
+	testWithMissingWasmFile,
 );

--- a/test/test.js
+++ b/test/test.js
@@ -241,7 +241,13 @@ async function runTests(...tests) {
 }
 
 async function testWithMissingWasmFile() {
-	const wasmPath = require('path').resolve(__dirname, '../xmllint.wasm');
+	// Locally xmllint.wasm is at the repo root; in CI the package is installed
+	// from a tarball into node_modules/xmllint-wasm/ so we fall back there.
+	const path = require('path');
+	let wasmPath = path.resolve(__dirname, '../xmllint.wasm');
+	if (!fs.existsSync(wasmPath)) {
+		wasmPath = path.join(path.dirname(require.resolve('xmllint-wasm')), 'xmllint.wasm');
+	}
 	const tmpPath = wasmPath + '.bak';
 	fs.renameSync(wasmPath, tmpPath);
 	try {


### PR DESCRIPTION
Add onAbort handler to the worker so that WASM initialization failures (e.g. missing wasm file, network error, CSP) post a message back to the main thread instead of leaving the Promise pending forever.

Also adds a test that temporarily hides xmllint.wasm and asserts the Promise rejects with a "WASM Abort" error message.

Fixes #33